### PR TITLE
Include meta tag indicating mobile-friendliness

### DIFF
--- a/html/src/main/webapp/index.html
+++ b/html/src/main/webapp/index.html
@@ -44,6 +44,7 @@
         }
     </style>
     <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
This tag came from reading about responsive design. The new tag makes it clear that our page is designed to be shown on mobile as well as desktop browsers. In my local tests, this did not seem to actually change any behavior: in the game, we're already scaling based on the size of the viewport we're given. This tag is a clue to search engines that we are ready to roll on different sizes and shapes of screens.